### PR TITLE
Added EJSON requirement

### DIFF
--- a/lib/LiveMysql.js
+++ b/lib/LiveMysql.js
@@ -5,6 +5,7 @@ var util = require('util');
 var _ = require('lodash');
 var ZongJi = require('zongji');
 var mysql = require('mysql2');
+var EJSON = require('ejson');
 
 // Maximum duration to wait for Zongji to initialize before timeout error (ms)
 var ZONGJI_INIT_TIMEOUT = 10000;


### PR DESCRIPTION
Hi vlasky, 

This to fix error on clean meteor project:

ReferenceError: EJSON is not defined
at LiveMysql.select (~/.meteor/packages/vlasky_mysql/.1.2.11.hhxkba.zumg5++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/mysql-live-select/lib/LiveMysql.js:159:23)