### PR TITLE
Ensure self.reconnectCount is incremented regardless of whether the t…

### DIFF
--- a/lib/LiveMysql.js
+++ b/lib/LiveMysql.js
@@ -52,7 +52,9 @@ LiveMysql.prototype.zongjiManager = function(dsn, options, onBinlog) {
     console.log("Performing reconnect attempt #" + (self.reconnectCount+1) + " of " + ZONGJI_MAX_RECONNECT_ATTEMPTS + " in " + reconnectDelay + " ms");
 
     setTimeout(function() {
-      // If multiple errors happened, a new instance may have already been created
+	  self.reconnectCount++;
+      
+	  // If multiple errors happened, a new instance may have already been created
       if(!('child' in self.zongji)) {
         let resumeoptions = {};
         if (self.zongji.options.position && self.zongji.options.filename) {
@@ -67,7 +69,7 @@ LiveMysql.prototype.zongjiManager = function(dsn, options, onBinlog) {
         self.zongji.child.on('child', child => self.zongji.emit('child', child, reason));
         self.zongji.emit('child', self.zongji.child, reason);
 
-        self.reconnectCount++;
+        
       }
     }, reconnectDelay);
   });


### PR DESCRIPTION
…imeout callback completes successfully, or throws an error.

This will ensure that we don't get stuck in an infinite loop which tries to reconnect to Zongji-Live-mysql forever.